### PR TITLE
Dop 1643

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ influxdb-athena-crawler takes as argument the parameters below.
 | timestamp-layout | The layout to parse timestamp. | `"2006-01-02T15:04:05.000Z"` |
 | tag | Tags to add to InfluxDB point. Could be of the form `--tag=foo` if tag name matches CSV row or `--tag='foo={row:bar}'` to specify row. | `""` |
 | field | Fields to add to InfluxDB point. Could be of the form `--field='foo={type:int,row:bar}'`, if not specified, CSV row matches field name. Type can be float, int, string or bool. | `""` |
+| max-routines | The max number of concurrent object processing routines. | `100` |
 
 ## License
 

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/influxdata/influxdb-client-go/v2 v2.13.0
 	github.com/jessevdk/go-flags v1.5.0
 	github.com/rs/zerolog v1.33.0
+	golang.org/x/sync v0.7.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -78,6 +78,8 @@ github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcU
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 golang.org/x/net v0.17.0 h1:pVaXccu2ozPjCXewfr1S7xza/zcXTity9cCdXQYSjIM=
 golang.org/x/net v0.17.0/go.mod h1:NxSsAGuq816PNPmqtQdLE42eU2Fs7NoRIZrHJAlaCOE=
+golang.org/x/sync v0.7.0 h1:YsImfSBoP9QPYL0xyKJPq0gcaJdG3rInoqxTWbfQu9M=
+golang.org/x/sync v0.7.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
 golang.org/x/sys v0.0.0-20210320140829-1e4c9ba3b0c4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/helm/influxdb-athena-crawler/Chart.yaml
+++ b/helm/influxdb-athena-crawler/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.4.0
+version: 1.5.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 0.5.0
+appVersion: 0.6.0

--- a/helm/influxdb-athena-crawler/README.md
+++ b/helm/influxdb-athena-crawler/README.md
@@ -1,6 +1,6 @@
 # influxdb-athena-crawler
 
-![Version: 1.4.0](https://img.shields.io/badge/Version-1.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.5.0](https://img.shields.io/badge/AppVersion-0.5.0-informational?style=flat-square)
+![Version: 1.5.0](https://img.shields.io/badge/Version-1.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.6.0](https://img.shields.io/badge/AppVersion-0.6.0-informational?style=flat-square)
 
 A cronjob that get athena reports on s3 and writes to influxdb periodically.
 
@@ -72,7 +72,6 @@ helm install influxdb-athena-crawler influxdb-athena-crawler/influxdb-athena-cra
 | defaults.fields | list | `[]` |  |
 | defaults.awsCredsSecret | string | `"aws-creds"` | A reference to a secret wit AWS credentials (must contain awsKeyId / awsSecretKey). |
 | defaults.schedule | string | `"0 0 * * *"` | The schedule in Cron format, see https://en.wikipedia.org/wiki/Cron. |
-| defaults.concurrencyPolicy | string | `"Forbid"` | Specifies how to treat concurrent executions of a Job (Allow / Forbid / Replace). |
 | defaults.backoffLimit | int | `6` | Specifies the number of retries before marking a job as failed. |
 | defaults.successfulJobsHistoryLimit | int | `3` | The number of successful finished jobs to retain. |
 | defaults.failedJobsHistoryLimit | int | `1` | The number of failed finished jobs to retain. |

--- a/helm/influxdb-athena-crawler/templates/_cronjob.yaml
+++ b/helm/influxdb-athena-crawler/templates/_cronjob.yaml
@@ -12,7 +12,7 @@ metadata:
     {{- include "influxdb-athena-crawler.labels" . | nindent 4 }}
 spec:
   schedule: {{ .Values.schedule | quote }}
-  concurrencyPolicy: {{ .Values.concurrencyPolicy }}
+  concurrencyPblicy: Forbid
   successfulJobsHistoryLimit: {{ .Values.successfulJobsHistoryLimit }}
   successfulJobsHistoryLimit: {{ .Values.successfulJobsHistoryLimit }}
   suspend: {{ .Values.suspend }}

--- a/helm/influxdb-athena-crawler/values.yaml
+++ b/helm/influxdb-athena-crawler/values.yaml
@@ -60,9 +60,6 @@ defaults:
   # -- The schedule in Cron format, see https://en.wikipedia.org/wiki/Cron.
   schedule: "0 0 * * *"
 
-  # -- Specifies how to treat concurrent executions of a Job (Allow / Forbid / Replace).
-  concurrencyPolicy: Forbid
-
   # -- Specifies the number of retries before marking a job as failed.
   backoffLimit: 6
 

--- a/main.go
+++ b/main.go
@@ -55,18 +55,37 @@ func main() {
 	}
 	s3Cli := s3.NewFromConfig(cfg)
 
-	// List objects matching bucket / prefix
-	res, err := s3Cli.ListObjects(ctx, &s3.ListObjectsInput{
-		Bucket: aws.String(opts.Bucket),
-		Prefix: aws.String(opts.Prefix),
-	})
-	if err != nil {
-		log.Fatal().Err(err).Msg("Unable to list objects")
+	maxKeys := int32(1000)
+	var elems s3.ListObjectsOutput
+
+	p := s3.NewListObjectsV2Paginator(
+		s3Cli,
+		&s3.ListObjectsV2Input{
+			Bucket:  aws.String(opts.Bucket),
+			Prefix:  aws.String(opts.Prefix),
+			MaxKeys: &maxKeys,
+		},
+		func(o *s3.ListObjectsV2PaginatorOptions) {
+			if v := int32(maxKeys); v != 0 {
+				o.Limit = v
+			}
+		})
+
+	var i int
+	for p.HasMorePages() {
+		i++
+		page, err := p.NextPage(ctx)
+		if err != nil {
+			log.Fatal().Err(err).Msg("Unable to get object page")
+		}
+
+		// Log the objects found
+		elems.Contents = slices.Concat(elems.Contents, page.Contents)
 	}
 
-	unprocCsvs, procCsvs := filterBucketContent(*res, opts.Suffix, opts.ProcessedFlagSuffix)
+	unprocCsvs, procCsvs, orphanFlags := filterBucketContent(elems, opts.Suffix, opts.ProcessedFlagSuffix)
 
-	if len(procCsvs.Contents)+len(unprocCsvs.Contents) == 0 {
+	if len(procCsvs.Contents)+len(unprocCsvs.Contents)+len(orphanFlags.Contents) == 0 {
 		log.Info().Msg("No objects matching bucket / prefix, processing done !")
 		return
 	}
@@ -102,46 +121,70 @@ func main() {
 		})
 	}
 
+	if len(orphanFlags.Contents) > 0 {
+		parallelApply(orphanFlags, func(o types.Object) {
+			if err := cleanObject(ctx, s3Cli, o); err != nil {
+				log.Error().Err(err).Msg("Cleaning error")
+			}
+		})
+	}
+
 	log.Info().
 		Dur("elapsed", time.Since(start)).
 		Msg("Processing ended !")
 }
 
-func filterBucketContent(elems s3.ListObjectsOutput, csvSuffix, processedFlagSuffix string) (unprocessed, processed s3.ListObjectsOutput) {
+func filterBucketContent(elems s3.ListObjectsOutput, csvSuffix, processedFlagSuffix string) (unprocessed, processed, orphanFlags s3.ListObjectsOutput) {
 	// Rely on .processed files present on the bucket to detect which csv
 	// has already been pushed to influx and which has yet to be processed
 	csvFiles := []types.Object{}
-	processedElems := []string{}
+	flags := []types.Object{}
+	objectNames := []string{}
+	flagNames := []string{}
 
 	if len(csvSuffix) == 0 {
-		return unprocessed, processed
+		return unprocessed, processed, orphanFlags
 	}
 	for _, s := range elems.Contents {
 		if strings.HasSuffix(*s.Key, csvSuffix) {
 			csvFiles = append(csvFiles, s)
+			objectNames = append(objectNames, *s.Key)
 		}
 		if strings.HasSuffix(*s.Key, processedFlagSuffix) {
-			processedElems = append(processedElems, strings.ReplaceAll(*s.Key, processedFlagSuffix, csvSuffix))
+			flags = append(flags, s)
+			flagNames = append(flagNames, *s.Key)
 		}
 	}
 
 	for _, o := range csvFiles {
-		if !slices.Contains(processedElems, *o.Key) {
+		flagName := strings.ReplaceAll(*o.Key, csvSuffix, processedFlagSuffix)
+		if !slices.Contains(flagNames, flagName) {
 			unprocessed.Contents = append(unprocessed.Contents, o)
 		} else {
 			processed.Contents = append(processed.Contents, o)
 		}
 	}
 
-	return unprocessed, processed
+	for _, f := range flags {
+		fileName := strings.ReplaceAll(*f.Key, processedFlagSuffix, csvSuffix)
+		if !slices.Contains(objectNames, fileName) {
+			orphanFlags.Contents = append(orphanFlags.Contents, f)
+		}
+
+	}
+
+	return unprocessed, processed, orphanFlags
 }
 
 func parallelApply(list s3.ListObjectsOutput, fn func(o types.Object)) {
+	semaphore := make(chan struct{}, opts.MaxRoutines)
 	var wg sync.WaitGroup
 	wg.Add(len(list.Contents))
 	for _, item := range list.Contents {
 		o := item
 		go func() {
+			semaphore <- struct{}{}        // Lock channel
+			defer func() { <-semaphore }() // Release channel
 			defer wg.Done()
 			fn(o)
 		}()
@@ -238,18 +281,20 @@ func cleanObject(
 			return err
 		}
 
-		markerFileName := strings.ReplaceAll(*o.Key, opts.Suffix, opts.ProcessedFlagSuffix)
-		_, err = s3Cli.DeleteObject(ctx, &s3.DeleteObjectInput{
-			Bucket: aws.String(opts.Bucket),
-			Key:    &markerFileName,
-		})
-		if err != nil {
-			log.Error().
-				Err(err).
-				Str("bucket", opts.Bucket).
-				Str("object", aws.ToString(o.Key)).
-				Msg("Unable to delete object")
-			return err
+		if !strings.Contains(*o.Key, opts.ProcessedFlagSuffix) {
+			markerFileName := strings.ReplaceAll(*o.Key, opts.Suffix, opts.ProcessedFlagSuffix)
+			_, err = s3Cli.DeleteObject(ctx, &s3.DeleteObjectInput{
+				Bucket: aws.String(opts.Bucket),
+				Key:    &markerFileName,
+			})
+			if err != nil {
+				log.Error().
+					Err(err).
+					Str("bucket", opts.Bucket).
+					Str("object", aws.ToString(o.Key)).
+					Msg("Unable to delete object")
+				return err
+			}
 		}
 	}
 	return nil

--- a/main.go
+++ b/main.go
@@ -58,18 +58,10 @@ func main() {
 	maxKeys := int32(1000)
 	var elems s3.ListObjectsOutput
 
-	p := s3.NewListObjectsV2Paginator(
-		s3Cli,
-		&s3.ListObjectsV2Input{
-			Bucket:  aws.String(opts.Bucket),
-			Prefix:  aws.String(opts.Prefix),
-			MaxKeys: &maxKeys,
-		},
-		func(o *s3.ListObjectsV2PaginatorOptions) {
-			if v := int32(maxKeys); v != 0 {
-				o.Limit = v
-			}
-		})
+	p := s3.NewListObjectsV2Paginator(s3Cli,&s3.ListObjectsV2Input{
+		Bucket:  aws.String(opts.Bucket),
+		Prefix:  aws.String(opts.Prefix),
+	})
 
 	for p.HasMorePages() {
 		page, err := p.NextPage(ctx)

--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -172,6 +172,7 @@ type Options struct {
 	TimestampLayout     string        `long:"timestamp-layout" description:"The layout to parse timestamp." default:"2006-01-02T15:04:05.000Z"`
 	Tags                []*Tag        `long:"tag" description:"Tags to add to InfluxDB point. Could be of the form --tag=foo if tag name matches CSV row or --tag='foo={row:bar}' to specify row."`
 	Fields              []*Field      `long:"field" description:"Fields to add to InfluxDB point. Could be of the form --field='foo={type:int,row:bar}', if not specified, CSV row matches field name. Type can be float, int, string or bool."`
+	MaxRoutines         int           `long:"max-routines" description:"How many routines should be created to parallelize object processing." default:"100"`
 }
 
 // Parse parses flags into give Option


### PR DESCRIPTION
This adds paginated reading of the bucket, which is useful if the chain was interrupted and the crawler needs to catch up on accumulated content.
This also adds cleaning of orphaned .processed files.
This also limits the number of parallel routines, again, useful if the crawler needs to catch up.
Finally, this also forces the concurrency policy to Forbid in the helm chart, as parallel execution of this tool on the same s3 prefix could lead to data duplication.