### PR TITLE
Process objects page per page and retire RetainWidows flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,6 @@ influxdb-athena-crawler takes as argument the parameters below.
 | suffix | Filename suffix to restrict files processed on the bucket. | `""` |
 | clean-objects | Whether to delete S3 objects after processing them. | `false` |
 | max-object-age | How long to wait since last modification before file cleaning. | `10m` |
-| retain-windows | When cleanup is activated, only trigger deletion at least this number of more recent metric folders exist. This requires the former to last element in the CSV path to be formatted as a timestamp. | `0` |
-| storage-timestamp-layout | The layout used in the last element of the CSV storage. | `"2006-01-02T15:04:05.000Z"` |
 | timeout | The global timeout. | `"30s"` |
 | influx-server | The InfluxDB server address. | `""` |
 | influx-token | The InfluxDB token. | `""` |

--- a/helm/influxdb-athena-crawler/Chart.yaml
+++ b/helm/influxdb-athena-crawler/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.7.0
+version: 1.8.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 0.7.0
+appVersion: 0.8.0

--- a/helm/influxdb-athena-crawler/README.md
+++ b/helm/influxdb-athena-crawler/README.md
@@ -1,6 +1,6 @@
 # influxdb-athena-crawler
 
-![Version: 1.7.0](https://img.shields.io/badge/Version-1.7.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.7.0](https://img.shields.io/badge/AppVersion-0.7.0-informational?style=flat-square)
+![Version: 1.8.0](https://img.shields.io/badge/Version-1.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.8.0](https://img.shields.io/badge/AppVersion-0.8.0-informational?style=flat-square)
 
 A cronjob that get athena reports on s3 and writes to influxdb periodically.
 
@@ -60,8 +60,6 @@ helm install influxdb-athena-crawler influxdb-athena-crawler/influxdb-athena-cra
 | defaults.processedFlagSuffix | string | `""` | The bucket processed flags suffix. |
 | defaults.cleanObjects | bool | `false` | Whether to delete S3 objects after processing them. |
 | defaults.maxObjectAge | string | `"5m"` | After how long to delete the objects. |
-| defaults.retainWindows | string | `""` | Wether to retain this number of most recent folders |
-| defaults.storageTimestampLayout | string | `""` | The timestamp layout used in folder naming used for the retainWindows flag. |
 | defaults.timeout | string | `"10m"` | The global timeout. |
 | defaults.influxServers | list | `[]` | The InfluxDB servers addresses. |
 | defaults.influxToken | string | `""` | The InfluxDB token. |

--- a/helm/influxdb-athena-crawler/templates/_cronjob.yaml
+++ b/helm/influxdb-athena-crawler/templates/_cronjob.yaml
@@ -72,12 +72,6 @@ spec:
                 {{- with .Values.maxObjectAge }}
                 - --max-object-age={{ . }}
                 {{- end }}
-                {{- with .Values.retainWindows }}
-                - --retain-windows={{ . }}
-                {{- end }}
-                {{- with .Values.storageTimestampLayout }}
-                - --storage-timestamp-layout={{ . }}
-                {{- end }}
                 {{- end }}
               env:
                 - name: AWS_ACCESS_KEY_ID

--- a/helm/influxdb-athena-crawler/values.yaml
+++ b/helm/influxdb-athena-crawler/values.yaml
@@ -24,12 +24,6 @@ defaults:
   # -- After how long to delete the objects.
   maxObjectAge: 5m
 
-  # -- If specified, always retain this number of most recent folders
-  retainWindows: ""
-
-  # -- The timestamp layout used in folder naming used for the retainWindows flag.
-  storageTimestampLayout: ""
-
   # -- The global timeout.
   timeout: 10m
 

--- a/main.go
+++ b/main.go
@@ -55,72 +55,64 @@ func main() {
 	}
 	s3Cli := s3.NewFromConfig(cfg)
 
-	var elems s3.ListObjectsOutput
-
 	p := s3.NewListObjectsV2Paginator(s3Cli, &s3.ListObjectsV2Input{
 		Bucket: aws.String(opts.Bucket),
 		Prefix: aws.String(opts.Prefix),
 	})
 
 	for p.HasMorePages() {
-		page, err := p.NextPage(ctx)
+		elems, err := p.NextPage(ctx)
 		if err != nil {
 			log.Fatal().Err(err).Msg("Unable to get object page")
 		}
 
-		// Log the objects found
-		elems.Contents = slices.Concat(elems.Contents, page.Contents)
-	}
+		unprocCsvs, procCsvs, orphanFlags := filterBucketContent(*elems, opts.Suffix, opts.ProcessedFlagSuffix)
 
-	unprocCsvs, procCsvs, orphanFlags := filterBucketContent(elems, opts.Suffix, opts.ProcessedFlagSuffix)
-
-	if len(procCsvs.Contents)+len(unprocCsvs.Contents)+len(orphanFlags.Contents) == 0 {
-		log.Info().Msg("No objects matching bucket / prefix, processing done !")
-		return
-	}
-
-	dwn := manager.NewDownloader(s3Cli)
-	upl := manager.NewUploader(s3Cli)
-	influxWriter := influxdb.NewWriters(
-		opts.InfluxServers,
-		opts.InfluxToken,
-		opts.InfluxOrg,
-		opts.InfluxBucket,
-		opts.Measurement,
-		opts.TimestampLayout,
-		opts.TimestampRow,
-		opts.Tags,
-		opts.Fields,
-	)
-	defer influxWriter.Close()
-
-	if len(unprocCsvs.Contents) > 0 {
-		err = parallelApply(ctx, unprocCsvs, func(o types.Object) error {
-			return processObject(ctx, dwn, upl, influxWriter, o)
-		})
-		if err != nil {
-			log.Fatal().Err(err).Msg("Failed processing objects")
+		if len(procCsvs.Contents)+len(unprocCsvs.Contents)+len(orphanFlags.Contents) == 0 {
+			log.Info().Msg("No objects matching bucket / prefix, processing done !")
+			return
 		}
-	}
 
-	// Only clean up processed files that are not in the opts.RetainWindows most recent folders
-	procCsvs = filterOutNewerWindows(procCsvs, opts.RetainWindows)
+		dwn := manager.NewDownloader(s3Cli)
+		upl := manager.NewUploader(s3Cli)
+		influxWriter := influxdb.NewWriters(
+			opts.InfluxServers,
+			opts.InfluxToken,
+			opts.InfluxOrg,
+			opts.InfluxBucket,
+			opts.Measurement,
+			opts.TimestampLayout,
+			opts.TimestampRow,
+			opts.Tags,
+			opts.Fields,
+		)
+		defer influxWriter.Close()
 
-	if opts.CleanObjects && len(procCsvs.Contents) > 0 {
-		err = parallelApply(ctx, procCsvs, func(o types.Object) error {
-			return cleanObject(ctx, s3Cli, o)
-		})
-		if err != nil {
-			log.Fatal().Err(err).Msg("Failed cleaning objects")
+		if len(unprocCsvs.Contents) > 0 {
+			err = parallelApply(ctx, unprocCsvs, func(o types.Object) error {
+				return processObject(ctx, dwn, upl, influxWriter, o)
+			})
+			if err != nil {
+				log.Fatal().Err(err).Msg("Failed processing objects")
+			}
 		}
-	}
 
-	if len(orphanFlags.Contents) > 0 {
-		err = parallelApply(ctx, orphanFlags, func(o types.Object) error {
-			return cleanObject(ctx, s3Cli, o)
-		})
-		if err != nil {
-			log.Fatal().Err(err).Msg("Failed cleaning orphan flags")
+		if opts.CleanObjects && len(procCsvs.Contents) > 0 {
+			err = parallelApply(ctx, procCsvs, func(o types.Object) error {
+				return cleanObject(ctx, s3Cli, o)
+			})
+			if err != nil {
+				log.Fatal().Err(err).Msg("Failed cleaning objects")
+			}
+		}
+
+		if len(orphanFlags.Contents) > 0 {
+			err = parallelApply(ctx, orphanFlags, func(o types.Object) error {
+				return cleanObject(ctx, s3Cli, o)
+			})
+			if err != nil {
+				log.Fatal().Err(err).Msg("Failed cleaning orphan flags")
+			}
 		}
 	}
 
@@ -132,7 +124,7 @@ func main() {
 // Rely on .processed files present on the bucket to detect which csv
 // has already been pushed to influx and which has yet to be processed
 // List .processed files that do not match any data file in order to clean them up, this can happen if the crawler was interrupted
-func filterBucketContent(elems s3.ListObjectsOutput, csvSuffix, processedFlagSuffix string) (unprocessed, processed, orphanFlags s3.ListObjectsOutput) {
+func filterBucketContent(elems s3.ListObjectsV2Output, csvSuffix, processedFlagSuffix string) (unprocessed, processed, orphanFlags s3.ListObjectsOutput) {
 	csvFiles := []types.Object{}
 	flags := []types.Object{}
 	objectNames := []string{}
@@ -170,52 +162,6 @@ func filterBucketContent(elems s3.ListObjectsOutput, csvSuffix, processedFlagSuf
 	}
 
 	return unprocessed, processed, orphanFlags
-}
-
-// Remove the <newestWindowCountToIgnore> most recent folders from the object listing in order to not clean them
-func filterOutNewerWindows(objects s3.ListObjectsOutput, newestWindowCountToIgnore int) (olderObjects s3.ListObjectsOutput) {
-	windowedObject := make(map[int64][]types.Object)
-	var windows []int64
-
-	if newestWindowCountToIgnore == 0 {
-		return objects
-	}
-
-	for _, o := range objects.Contents {
-		path := strings.Split(*o.Key, "/")
-		if len(path) < 2 {
-			log.Error().
-				Str("object", aws.ToString(o.Key)).
-				Msg("No timestamp in path")
-			continue
-		}
-		// We expect the beginning of the time window of each CSV to be the former to last element of the S3 path
-		ts, err := time.Parse(opts.StorageTimestampLayout, path[len(path)-2])
-		if err != nil {
-			log.Error().
-				Err(err).
-				Str("object", aws.ToString(o.Key)).
-				Str("time-window", path[len(path)-2]).
-				Msg("Unable to parse object time window")
-			continue
-		}
-		windowedObject[ts.UnixMilli()] = append(windowedObject[ts.UnixMilli()], o)
-		if !slices.Contains(windows, ts.UnixMilli()) {
-			windows = append(windows, ts.UnixMilli())
-		}
-	}
-
-	slices.Sort(windows)
-	slices.Reverse(windows)
-	// Return all the objects, except the ones in the "newestWindowCountToIgnore" last windows
-	for i, window := range windows {
-		if i < newestWindowCountToIgnore {
-			continue
-		}
-		olderObjects.Contents = slices.Concat(olderObjects.Contents, windowedObject[window])
-	}
-
-	return olderObjects
 }
 
 func parallelApply(ctx context.Context, list s3.ListObjectsOutput, fn func(o types.Object) error) error {

--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -155,26 +155,24 @@ func (f *Field) MarshalFlag() (string, error) {
 
 // Options wraps all flags
 type Options struct {
-	Region                 string        `long:"region" description:"The AWS region." required:"true"`
-	Bucket                 string        `long:"bucket" description:"The AWS bucket to watch." required:"true"`
-	Prefix                 string        `long:"prefix" description:"The bucket prefix."`
-	Suffix                 string        `long:"suffix" description:"Filename suffix to limit files read on the bucket."`
-	ProcessedFlagSuffix    string        `long:"processed-flag-suffix" description:"Filename suffix to mark csv files as processed on the bucket." default:"processed"`
-	CleanObjects           bool          `long:"clean-objects" description:"Whether to delete S3 objects after processing them."`
-	MaxObjectAge           time.Duration `long:"max-object-age" description:"When cleanup is activated, only trigger deletion if csv is at least this old." default:"10m"`
-	RetainWindows          int           `long:"retain-windows" description:"When cleanup is activated, only trigger deletion at least this number of more recent metric folders exist." default:"0"`
-	StorageTimestampLayout string        `long:"storage-timestamp-layout" description:"The layout used for csv file storage, e.g. part of the S3 path." default:"2006-01-02T15:04:05.000Z"`
-	Timeout                time.Duration `long:"timeout" description:"The global timeout." default:"30s"`
-	InfluxServers          []string      `long:"influx-server" description:"The InfluxDB servers addresses." required:"true"`
-	InfluxToken            string        `long:"influx-token" description:"The InfluxDB token." required:"true"`
-	InfluxOrg              string        `long:"influx-org" description:"The InfluxDB org to write to." required:"true"`
-	InfluxBucket           string        `long:"influx-bucket" description:"The InfluxDB bucket write to." required:"true"`
-	Measurement            string        `long:"measurement" description:"A measurement acts as a container for tags, fields, and timestamps. Use a measurement name that describes your data." required:"true"`
-	TimestampRow           string        `long:"timestamp-row" description:"The timestamp row in CSV." default:"timestamp"`
-	TimestampLayout        string        `long:"timestamp-layout" description:"The layout to parse timestamp." default:"2006-01-02T15:04:05.000Z"`
-	Tags                   []*Tag        `long:"tag" description:"Tags to add to InfluxDB point. Could be of the form --tag=foo if tag name matches CSV row or --tag='foo={row:bar}' to specify row."`
-	Fields                 []*Field      `long:"field" description:"Fields to add to InfluxDB point. Could be of the form --field='foo={type:int,row:bar}', if not specified, CSV row matches field name. Type can be float, int, string or bool."`
-	MaxRoutines            int           `long:"max-routines" description:"How many routines should be created to parallelize object processing." default:"100"`
+	Region              string        `long:"region" description:"The AWS region." required:"true"`
+	Bucket              string        `long:"bucket" description:"The AWS bucket to watch." required:"true"`
+	Prefix              string        `long:"prefix" description:"The bucket prefix."`
+	Suffix              string        `long:"suffix" description:"Filename suffix to limit files read on the bucket."`
+	ProcessedFlagSuffix string        `long:"processed-flag-suffix" description:"Filename suffix to mark csv files as processed on the bucket." default:"processed"`
+	CleanObjects        bool          `long:"clean-objects" description:"Whether to delete S3 objects after processing them."`
+	MaxObjectAge        time.Duration `long:"max-object-age" description:"When cleanup is activated, only trigger deletion if csv is at least this old." default:"10m"`
+	Timeout             time.Duration `long:"timeout" description:"The global timeout." default:"30s"`
+	InfluxServers       []string      `long:"influx-server" description:"The InfluxDB servers addresses." required:"true"`
+	InfluxToken         string        `long:"influx-token" description:"The InfluxDB token." required:"true"`
+	InfluxOrg           string        `long:"influx-org" description:"The InfluxDB org to write to." required:"true"`
+	InfluxBucket        string        `long:"influx-bucket" description:"The InfluxDB bucket write to." required:"true"`
+	Measurement         string        `long:"measurement" description:"A measurement acts as a container for tags, fields, and timestamps. Use a measurement name that describes your data." required:"true"`
+	TimestampRow        string        `long:"timestamp-row" description:"The timestamp row in CSV." default:"timestamp"`
+	TimestampLayout     string        `long:"timestamp-layout" description:"The layout to parse timestamp." default:"2006-01-02T15:04:05.000Z"`
+	Tags                []*Tag        `long:"tag" description:"Tags to add to InfluxDB point. Could be of the form --tag=foo if tag name matches CSV row or --tag='foo={row:bar}' to specify row."`
+	Fields              []*Field      `long:"field" description:"Fields to add to InfluxDB point. Could be of the form --field='foo={type:int,row:bar}', if not specified, CSV row matches field name. Type can be float, int, string or bool."`
+	MaxRoutines         int           `long:"max-routines" description:"How many routines should be created to parallelize object processing." default:"100"`
 }
 
 // Parse parses flags into give Option


### PR DESCRIPTION
This remove the retainWindow and timestampStorage options, as they required parsing the entire bucket before filtering, which prevented efficient processing of buckets with objects spread across many pages.
This also processes pages independently one after the other.